### PR TITLE
AWS Provider 4.0 Changes

### DIFF
--- a/infra.tf
+++ b/infra.tf
@@ -8,6 +8,13 @@ resource "aws_s3_bucket_acl" "etcd_backups_acl" {
   acl    = "private"
 }
 
+resource "aws_s3_bucket_versioning" "etcd_backups_versioning" {
+  bucket = aws_s3_bucket.etcd_backups.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "etcd_backups_server_side_encryption_configuration" {
   bucket = aws_s3_bucket.etcd_backups.id
 

--- a/infra.tf
+++ b/infra.tf
@@ -1,6 +1,5 @@
 resource "aws_s3_bucket" "etcd_backups" {
   bucket_prefix = "${local.name}-etcd-backup"
-  acl           = "private"
   force_destroy = true
 }
 

--- a/infra.tf
+++ b/infra.tf
@@ -2,17 +2,20 @@ resource "aws_s3_bucket" "etcd_backups" {
   bucket_prefix = "${local.name}-etcd-backup"
   acl           = "private"
   force_destroy = true
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "aws:kms"
-      }
+resource "aws_s3_bucket_acl" "etcd_backups_acl" {
+  bucket = aws_s3_bucket.etcd_backups.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "etcd_backups_server_side_encryption_configuration" {
+  bucket = aws_s3_bucket.etcd_backups.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
     }
-  }
-
-  versioning {
-    enabled = true
   }
 }
 


### PR DESCRIPTION
Following the changes for https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#s3-bucket-refactor. Since, this module currently doesn't pin the provider version.